### PR TITLE
Add Ntfy.sh delivery, delivery interfacing

### DIFF
--- a/PushyFinder/Configuration.cs
+++ b/PushyFinder/Configuration.cs
@@ -1,5 +1,6 @@
-﻿using Dalamud.Configuration;
+using Dalamud.Configuration;
 using Dalamud.Plugin;
+using PushyFinder.Delivery;
 using System;
 
 namespace PushyFinder
@@ -9,9 +10,15 @@ namespace PushyFinder
     {
         public int Version { get; set; } = 1;
 
+        public deliveries DeliveryService { get; set; } = deliveries.Pushover;
+
         public string PushoverAppKey { get; set; } = "";
         public string PushoverUserKey { get; set; } = "";
         public string PushoverDevice { get; set; } = "";
+
+        public string ntfyTopic { get; set; } = "";
+        public string ntfyDomain { get; set; } = "https://ntfy.sh/";
+
         public bool EnableForDutyPops { get; set; } = true;
 
         // the below exist just to make saving less cumbersome

--- a/PushyFinder/Configuration.cs
+++ b/PushyFinder/Configuration.cs
@@ -10,14 +10,14 @@ namespace PushyFinder
     {
         public int Version { get; set; } = 1;
 
-        public deliveries DeliveryService { get; set; } = deliveries.Pushover;
+        public Deliveries DeliveryService { get; set; } = Deliveries.Pushover;
 
         public string PushoverAppKey { get; set; } = "";
         public string PushoverUserKey { get; set; } = "";
         public string PushoverDevice { get; set; } = "";
 
-        public string ntfyTopic { get; set; } = "";
-        public string ntfyDomain { get; set; } = "https://ntfy.sh/";
+        public string NtfyTopic { get; set; } = "";
+        public string NtfyDomain { get; set; } = "https://ntfy.sh/";
 
         public bool EnableForDutyPops { get; set; } = true;
 

--- a/PushyFinder/Delivery/Delivery.cs
+++ b/PushyFinder/Delivery/Delivery.cs
@@ -12,7 +12,7 @@ namespace PushyFinder.Delivery
         public abstract static void Deliver(string title, string text = "");
     }
 
-    public enum deliveries
+    public enum Deliveries
     {
         Pushover,
         Ntfy,
@@ -24,8 +24,8 @@ namespace PushyFinder.Delivery
         {
             return Plugin.Configuration.DeliveryService switch
             {
-                deliveries.Pushover => PushoverDelivery.Deliver,
-                deliveries.Ntfy => NtfyDelivery.Deliver,
+                Deliveries.Pushover => PushoverDelivery.Deliver,
+                Deliveries.Ntfy => NtfyDelivery.Deliver,
                 _ => throw new NotImplementedException($"Unsupported Delivery Destination {Plugin.Configuration.DeliveryService}"),
             };
         }

--- a/PushyFinder/Delivery/Delivery.cs
+++ b/PushyFinder/Delivery/Delivery.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PushyFinder.Delivery
+{
+    internal interface IDelivery
+    {
+        public abstract static String Name { get; }
+        public abstract static void Deliver(string title, string text = "");
+    }
+
+    public enum deliveries
+    {
+        Pushover,
+        Ntfy,
+    }
+
+    public static class DeliveryManager
+    {
+        public static Action<string, string> Deliver()
+        {
+            return Plugin.Configuration.DeliveryService switch
+            {
+                deliveries.Pushover => PushoverDelivery.Deliver,
+                deliveries.Ntfy => NtfyDelivery.Deliver,
+                _ => throw new NotImplementedException($"Unsupported Delivery Destination {Plugin.Configuration.DeliveryService}"),
+            };
+        }
+    }
+}

--- a/PushyFinder/Delivery/NtfyDelivery.cs
+++ b/PushyFinder/Delivery/NtfyDelivery.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Dalamud.Logging;
+using Flurl.Http;
+
+namespace PushyFinder.Delivery;
+
+public abstract class NtfyDelivery : IDelivery
+{
+    public static string Name => "Ntfy.sh";
+
+    public static void Deliver(string title, string text = "")
+    {
+        if (Plugin.Configuration.ntfyTopic.Length == 0 ||
+            Plugin.Configuration.ntfyDomain.Length == 0) return;
+        
+        Task.Run(() => DeliverAsync(title, text));
+    }
+
+    private static async void DeliverAsync(string title, string text)
+    {
+        try
+        {
+            var url = Plugin.Configuration.ntfyDomain + Plugin.Configuration.ntfyTopic;
+
+            await url.WithHeader("Title", title).PostStringAsync(text);
+        }
+        catch (FlurlHttpException e)
+        {
+            PluginLog.Error($"Failed to make ntfy req: '{e.Message}'");
+            PluginLog.Error($"{e.StackTrace}");
+        }
+    }
+}

--- a/PushyFinder/Delivery/NtfyDelivery.cs
+++ b/PushyFinder/Delivery/NtfyDelivery.cs
@@ -12,8 +12,8 @@ public abstract class NtfyDelivery : IDelivery
 
     public static void Deliver(string title, string text = "")
     {
-        if (Plugin.Configuration.ntfyTopic.Length == 0 ||
-            Plugin.Configuration.ntfyDomain.Length == 0) return;
+        if (Plugin.Configuration.NtfyTopic.Length == 0 ||
+            Plugin.Configuration.NtfyDomain.Length == 0) return;
         
         Task.Run(() => DeliverAsync(title, text));
     }
@@ -22,7 +22,7 @@ public abstract class NtfyDelivery : IDelivery
     {
         try
         {
-            var url = Plugin.Configuration.ntfyDomain + Plugin.Configuration.ntfyTopic;
+            var url = Plugin.Configuration.NtfyDomain + Plugin.Configuration.NtfyTopic;
 
             await url.WithHeader("Title", title).PostStringAsync(text);
         }

--- a/PushyFinder/Delivery/PushoverDelivery.cs
+++ b/PushyFinder/Delivery/PushoverDelivery.cs
@@ -5,10 +5,11 @@ using Flurl.Http;
 
 namespace PushyFinder.Delivery;
 
-public static class PushoverDelivery
+public abstract class PushoverDelivery : IDelivery
 {
+    public static string Name => "Pushover.net";
     public static readonly string PUSHOVER_API = "https://api.pushover.net/1/messages.json";
-    
+
     public static void Deliver(string title, string text = "")
     {
         if (Plugin.Configuration.PushoverAppKey.Length == 0 ||

--- a/PushyFinder/Impl/DutyListener.cs
+++ b/PushyFinder/Impl/DutyListener.cs
@@ -29,6 +29,6 @@ public class DutyListener
             return;
         
         var dutyName = e.RowId == 0 ? "Duty Roulette" : e.Name.ToDalamudString().TextValue;
-        PushoverDelivery.Deliver($"Duty pop", $"Duty registered: '{dutyName}'.");
+        DeliveryManager.Deliver().Invoke($"Duty pop", $"Duty registered: '{dutyName}'.");
     }
 }

--- a/PushyFinder/Impl/PartyListener.cs
+++ b/PushyFinder/Impl/PartyListener.cs
@@ -31,12 +31,12 @@ public static class PartyListener
 
         if (m.PartyCount == 8)
         {
-            PushoverDelivery.Deliver("Party full",
+            DeliveryManager.Deliver().Invoke("Party full",
                                      $"{m.Name} (Lv{m.Level} {jobAbbr}) joins the party.\nParty recruitment ended. All spots have been filled.");
         }
         else
         {
-            PushoverDelivery.Deliver($"{m.PartyCount}/8: Party join",
+            DeliveryManager.Deliver().Invoke($"{m.PartyCount}/8: Party join",
                                      $"{m.Name} (Lv{m.Level} {jobAbbr}) joins the party.");
         }
     }
@@ -47,7 +47,7 @@ public static class PartyListener
         
         var jobAbbr = LuminaDataUtil.GetJobAbbreviation(m.JobId);
 
-        PushoverDelivery.Deliver($"{m.PartyCount-1}/8: Party leave",
+        DeliveryManager.Deliver().Invoke($"{m.PartyCount-1}/8: Party leave",
                                  $"{m.Name} (Lv{m.Level} {jobAbbr}) has left the party.");
     }
 }

--- a/PushyFinder/Plugin.cs
+++ b/PushyFinder/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.Command;
+using Dalamud.Game.Command;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using System.IO;

--- a/PushyFinder/Windows/ConfigWindow.cs
+++ b/PushyFinder/Windows/ConfigWindow.cs
@@ -25,25 +25,53 @@ public class ConfigWindow : Window, IDisposable
 
     public override void Draw()
     {
+        var service = Configuration.DeliveryService;
+        if (ImGui.BeginCombo("Service", service.ToString()))
         {
-            var cfg = Configuration.PushoverAppKey;
-            if (ImGui.InputText("Application key", ref cfg, 2048u))
+            foreach (var item in Enum.GetValues<deliveries>())
             {
-                Configuration.PushoverAppKey = cfg;
+                if (ImGui.Selectable(item.ToString(), Configuration.DeliveryService == item)) Configuration.DeliveryService = item;
             }
         }
+        if (service == Delivery.deliveries.Pushover)
         {
-            var cfg = Configuration.PushoverUserKey;
-            if (ImGui.InputText("User key", ref cfg, 2048u))
             {
-                Configuration.PushoverUserKey = cfg;
+                var cfg = Configuration.PushoverAppKey;
+                if (ImGui.InputText("Application key", ref cfg, 2048u))
+                {
+                    Configuration.PushoverAppKey = cfg;
+                }
+            }
+            {
+                var cfg = Configuration.PushoverUserKey;
+                if (ImGui.InputText("User key", ref cfg, 2048u))
+                {
+                    Configuration.PushoverUserKey = cfg;
+                }
+            }
+            {
+                var cfg = Configuration.PushoverDevice;
+                if (ImGui.InputText("Device name", ref cfg, 2048u))
+                {
+                    Configuration.PushoverDevice = cfg;
+                }
             }
         }
+        else if (service == deliveries.Ntfy)
         {
-            var cfg = Configuration.PushoverDevice;
-            if (ImGui.InputText("Device name", ref cfg, 2048u))
             {
-                Configuration.PushoverDevice = cfg;
+                var cfg = Configuration.ntfyTopic;
+                if (ImGui.InputText("Topic", ref cfg, 2048u))
+                {
+                    Configuration.ntfyTopic = cfg;
+                }
+            }
+            {
+                var cfg = Configuration.ntfyDomain;
+                if (ImGui.InputText("Domain", ref cfg, 2048u))
+                {
+                    Configuration.ntfyDomain = cfg;
+                }
             }
         }
         {
@@ -57,7 +85,7 @@ public class ConfigWindow : Window, IDisposable
         if (ImGui.Button("Send test notification"))
         {
             notifSentMessageTimer.Start();
-            PushoverDelivery.Deliver("Test notification", 
+            DeliveryManager.Deliver().Invoke("Test notification", 
                                      "If you received this, PushyFinder is configured correctly.");
         }
 

--- a/PushyFinder/Windows/ConfigWindow.cs
+++ b/PushyFinder/Windows/ConfigWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Numerics;
 using Dalamud.Interface.Windowing;
 using ImGuiNET;
@@ -28,12 +28,12 @@ public class ConfigWindow : Window, IDisposable
         var service = Configuration.DeliveryService;
         if (ImGui.BeginCombo("Service", service.ToString()))
         {
-            foreach (var item in Enum.GetValues<deliveries>())
+            foreach (var item in Enum.GetValues<Deliveries>())
             {
                 if (ImGui.Selectable(item.ToString(), Configuration.DeliveryService == item)) Configuration.DeliveryService = item;
             }
         }
-        if (service == Delivery.deliveries.Pushover)
+        if (service == Deliveries.Pushover)
         {
             {
                 var cfg = Configuration.PushoverAppKey;
@@ -57,20 +57,20 @@ public class ConfigWindow : Window, IDisposable
                 }
             }
         }
-        else if (service == deliveries.Ntfy)
+        else if (service == Deliveries.Ntfy)
         {
             {
-                var cfg = Configuration.ntfyTopic;
+                var cfg = Configuration.NtfyTopic;
                 if (ImGui.InputText("Topic", ref cfg, 2048u))
                 {
-                    Configuration.ntfyTopic = cfg;
+                    Configuration.NtfyTopic = cfg;
                 }
             }
             {
-                var cfg = Configuration.ntfyDomain;
+                var cfg = Configuration.NtfyDomain;
                 if (ImGui.InputText("Domain", ref cfg, 2048u))
                 {
-                    Configuration.ntfyDomain = cfg;
+                    Configuration.NtfyDomain = cfg;
                 }
             }
         }


### PR DESCRIPTION
In order to make the plugin more accessible, I've added an interface for deliveries and added FOSS project [ntfy](https://ntfy.sh/) as a supported service, with support for custom servers if anyone is running the server on their own hardware

![image](https://user-images.githubusercontent.com/12771982/226235826-65fc99b4-9f05-4159-a0e2-c1c40d0f994f.png)

The way I've done this is at the best of my ability, it unfortunately won't scale up very well if people were to add more services as the configuration is still contained entirely within the window class, and the deliverymanager has to redefine what enum entry points to which delivery function is used.
I'd have loved to a reference of sorts in the configuration but this is where I struggled to find a solution