### PR TITLE
Small Fix: Safety net for Requests on things that aren't url

### DIFF
--- a/PushyFinder/Delivery/DiscordDelivery.cs
+++ b/PushyFinder/Delivery/DiscordDelivery.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Dalamud.Utility;
@@ -8,7 +9,8 @@ namespace PushyFinder.Delivery;
 
 internal class DiscordDelivery : IDelivery
 {
-    public bool IsActive => !Plugin.Configuration.DiscordWebhookToken.IsNullOrWhitespace();
+    public bool IsActive => !Plugin.Configuration.DiscordWebhookToken.IsNullOrWhitespace() && 
+                            Uri.IsWellFormedUriString(Plugin.Configuration.DiscordWebhookToken, UriKind.Absolute);
 
     public void Deliver(string title, string text)
     {
@@ -48,6 +50,10 @@ internal class DiscordDelivery : IDelivery
             Service.PluginLog.Error($"Failed to make Discord request: '{e.Message}'");
             Service.PluginLog.Error($"{e.StackTrace}");
             Service.PluginLog.Debug(JsonSerializer.Serialize(webhook.Build()));
+        }
+        catch (ArgumentException e)
+        {
+            Service.PluginLog.Error($"{e.StackTrace}");
         }
     }
 }

--- a/PushyFinder/Delivery/NtfyDelivery.cs
+++ b/PushyFinder/Delivery/NtfyDelivery.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Dalamud.Utility;
@@ -8,7 +9,8 @@ namespace PushyFinder.Delivery;
 public class NtfyDelivery : IDelivery
 {
     public bool IsActive => !Plugin.Configuration.NtfyServer.IsNullOrWhitespace() &&
-                            !Plugin.Configuration.NtfyTopic.IsNullOrWhitespace();
+                            !Plugin.Configuration.NtfyTopic.IsNullOrWhitespace() && 
+                            Uri.IsWellFormedUriString(Plugin.Configuration.NtfyServer, UriKind.Absolute);
 
     public void Deliver(string title, string text)
     {
@@ -17,7 +19,7 @@ public class NtfyDelivery : IDelivery
 
     private static async void DeliverAsync(string title, string text)
     {
-        var args = new Dictionary<string, string>
+            var args = new Dictionary<string, string>
         {
             { "topic", Plugin.Configuration.NtfyTopic },
             { "title", title },
@@ -39,5 +41,10 @@ public class NtfyDelivery : IDelivery
             Service.PluginLog.Error($"Failed to make Ntfy request: '{e.Message}'");
             Service.PluginLog.Error($"{e.StackTrace}");
         }
+        catch (ArgumentException e)
+        {
+            Service.PluginLog.Error($"{e.StackTrace}");
+        }
+
     }
 }

--- a/PushyFinder/Windows/ConfigWindow.cs
+++ b/PushyFinder/Windows/ConfigWindow.cs
@@ -60,7 +60,7 @@ public class ConfigWindow : Window, IDisposable
     {
         {
             var cfg = Configuration.DiscordWebhookToken;
-            if (ImGui.InputText("Webhook token", ref cfg, 2048u)) Configuration.DiscordWebhookToken = cfg;
+            if (ImGui.InputText("Webhook URL", ref cfg, 2048u)) Configuration.DiscordWebhookToken = cfg;
         }
         {
             var cfg = Configuration.DiscordUseEmbed;


### PR DESCRIPTION
So I wanted to try the pluging with Discord and when I tried to put my token on the "webhook token" field it crashed my game; I took a look at the code and figured out that it wanted the whole url for discord webhooks, so I updated that part of the UI to "webhooks URL" and put a few checks on the Deliveries (Discord & Ntfy) so it tests for a valid url before setting the delivery as active, I tested with a few custom urls (selfhosted & Base Ntfy, discord webhooks) and it seems to work fine! Also added a Argument Exception just in case.
Thanks for the Plugin! Helps a lot 😃 